### PR TITLE
fix(releaser): Pin opam-publish to 2.0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build archive
         run: |
@@ -88,9 +88,11 @@ jobs:
         with:
           ocaml-compiler: 4.12.0
 
+      # Version 2.1.0 of opam-publish doesn't respect OPAMYES=1
+      # Ref https://github.com/ocaml-opam/opam-publish/issues/132#issuecomment-963616802
       - name: Install publish utils
         run: |
-          opam install opam-publish
+          opam install opam-publish=2.0.3
 
       - name: Publish to opam
         run: |


### PR DESCRIPTION
Closes #4

I tested this locally and 2.0.3 seems to continue respecting the `OPAMYES=1` env var that is set by setup-ocaml.