### PR TITLE
chore: Add conf-python-3 dependency for esy builds

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a76af2a5f90fd9d38fd5daef38abe3bf",
+  "checksum": "0f219fb1d4cb3539a7b266e15c1decc5",
   "root": "@grain/libbinaryen@link-dev:./package.json",
   "node": {
     "ocaml@4.12.0@d41d8cd9": {
@@ -1062,6 +1062,23 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
+    "@opam/conf-python-3@opam:1.0.0@5a2ad0fc": {
+      "id": "@opam/conf-python-3@opam:1.0.0@5a2ad0fc",
+      "name": "@opam/conf-python-3",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-python-3",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/conf-python-3.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
+      "devDependencies": []
+    },
     "@opam/conf-cmake@github:grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869@d41d8cd9": {
       "id":
         "@opam/conf-cmake@github:grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869@d41d8cd9",
@@ -1227,6 +1244,7 @@
         "ocaml@4.12.0@d41d8cd9",
         "@opam/dune-configurator@opam:2.9.1@b7cf7a02",
         "@opam/dune@opam:2.9.1@1e504822",
+        "@opam/conf-python-3@opam:1.0.0@5a2ad0fc",
         "@opam/conf-cmake@github:grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869@d41d8cd9"
       ],
       "devDependencies": [

--- a/esy.lock/opam/conf-python-3.1.0.0/files/test.py
+++ b/esy.lock/opam/conf-python-3.1.0.0/files/test.py
@@ -1,0 +1,1 @@
+print('python-3 OK')

--- a/esy.lock/opam/conf-python-3.1.0.0/opam
+++ b/esy.lock/opam/conf-python-3.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://www.python.org/download/releases/3.6"
+authors: "Python Software Foundation"
+license: "PSF"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: ["python3" "test.py"]
+depexts: [
+  ["python3"] {os-family = "debian"}
+  ["python3"] {os-distribution = "nixos"}
+  ["python3"] {os-distribution = "alpine"}
+  ["python36" "epel-release"] {os-distribution = "centos"}
+  ["python3"] {os-distribution = "fedora"}
+  ["python3"] {os-distribution = "ol"}
+  ["python"] {os-distribution = "arch"}
+  ["python3"] {os-family = "suse"}
+  ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
+  ["python3"] {os = "openbsd"}
+  ["lang/python36"] {os = "netbsd"}
+  ["lang/python36"] {os = "freebsd"}
+  ["python36"] {os-distribution = "macports" & os = "macos"}
+  ["python3"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on Python-3 installation"
+description: """
+This package can only install if a Python-3 interpreter is available
+on the system.
+If a minor version needs to be specified for your operating system, then
+python-3.6 will be used.
+"""
+extra-files: ["test.py" "md5=db8829ab1f4aa1fc15f380afba9d01f5"]
+flags: conf

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "ocaml": "4.12.0",
     "@opam/conf-cmake": "grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869",
+    "@opam/conf-python-3": "^1.0.0",
     "@opam/dune": "^2.9.1",
     "@opam/dune-configurator": "^2.9.1"
   },


### PR DESCRIPTION
Closes #9 

As mentioned in the original issue, I'm not sure if this is the best solution, but I *really* **really** don't want to depend on esy-python as it builds CPython from source and doesn't work very well (especially on windows). I'd rather our consumers just need to have python3 installed globally in on of the locations that esy looks for tools.