### PR TITLE
fix: Always have a target on non-Windows/non-MacOS

### DIFF
--- a/dune
+++ b/dune
@@ -69,7 +69,9 @@
  (deps
   (source_tree binaryen))
  (enabled_if
-  (= %{system} linux))
+  (and
+   (<> %{system} macosx)
+   (<> %{system} mingw64)))
  (action
   (no-infer
    (progn


### PR DESCRIPTION
It seems that not all linux are marked as linux on opam-ci. We should always have a target for dllbinaryen.so (and I think we can assume it'll be built like linux).