### PR TITLE
chore: Drop Windows support in opam CI

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         ocaml-compiler: [4.12.0]
 
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
It doesn't work like 80% of the time (or 100% of the time right now).