### PR TITLE
feat!: Bump binaryen to version_103

### DIFF
--- a/dune
+++ b/dune
@@ -33,7 +33,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_C_FLAGS=
+     -DCMAKE_CXX_FLAGS=
      "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=ON
      -DCMAKE_BUILD_TYPE=Release
@@ -59,7 +59,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_C_FLAGS=
+     -DCMAKE_CXX_FLAGS=
      "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
@@ -87,7 +87,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_C_FLAGS=
+     -DCMAKE_CXX_FLAGS=
      "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
@@ -113,7 +113,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_C_FLAGS=
+     -DCMAKE_CXX_FLAGS=
      "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release

--- a/dune
+++ b/dune
@@ -33,8 +33,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=
-     "-Wno-unused-variable"
+     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
      -DBUILD_STATIC_LIB=ON
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -59,8 +58,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=
-     "-Wno-unused-variable"
+     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -87,8 +85,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=
-     "-Wno-unused-variable"
+     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -113,8 +110,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=
-     "-Wno-unused-variable"
+     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)

--- a/dune
+++ b/dune
@@ -33,6 +33,8 @@
      binaryen
      -G
      "Unix Makefiles"
+     -DCMAKE_C_FLAGS=
+     "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=ON
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -57,6 +59,8 @@
      binaryen
      -G
      "Unix Makefiles"
+     -DCMAKE_C_FLAGS=
+     "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -83,6 +87,8 @@
      binaryen
      -G
      "Unix Makefiles"
+     -DCMAKE_C_FLAGS=
+     "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)
@@ -107,6 +113,8 @@
      binaryen
      -G
      "Unix Makefiles"
+     -DCMAKE_C_FLAGS=
+     "-Wno-unused-variable"
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)


### PR DESCRIPTION
This bumps binaryen for the `version_103` tag. Doesn't seem like any other change is necessary.