### PR TITLE
chore: Fix opam release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup opam repository
         run: |
           mkdir -p  ~/.opam/plugins/opam-publish/repos/
-          git clone git://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
+          git clone https://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           cd ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           git remote add user https://${{ secrets.OPAM_RELEASE }}@github.com/grainbot/opam-repository
 


### PR DESCRIPTION
GitHub removed `git://` support today: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Switch to using `https://` for the initial clone so our release workflow works.