### PR TITLE
chore: Release on the v102 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup opam repository
         run: |
           mkdir -p  ~/.opam/plugins/opam-publish/repos/
-          git clone git://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
+          git clone https://github.com/ocaml/opam-repository ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           cd ~/.opam/plugins/opam-publish/repos/ocaml%opam-repository
           git remote add user https://${{ secrets.OPAM_RELEASE }}@github.com/grainbot/opam-repository
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v102
 
 jobs:
   release-please:


### PR DESCRIPTION
This adds the ability for the releaser action to run on the v102 branch. This branch is created from the v102.0.0 tag so I can perform a bug fix related to the wasm-delegations.def file.