### PR TITLE
fix: Copy wasm-delegations.def into the correct location

### DIFF
--- a/dune
+++ b/dune
@@ -7,6 +7,12 @@
  (c_library_flags :standard -lstdc++ -lpthread)
  (install_c_headers binaryen-c))
 
+(install
+ (section lib)
+ (package libbinaryen)
+ (files
+  (wasm-delegations.def as c/wasm-delegations.def)))
+
 (rule
  (targets binaryen-c.h wasm-delegations.def)
  (deps


### PR DESCRIPTION
When trying to upgrade binaryen.ml, it failed because `wasm-delegations.def` couldn't be located.

The only way to really test this is with an esy resolution so I'm going to open a related PR over there.

Relies on #27 so I can trigger a release.