### PR TITLE
fix: Copy wasm-delegations.def into the correct location (#28)

### DIFF
--- a/dune
+++ b/dune
@@ -7,6 +7,12 @@
  (c_library_flags :standard -lstdc++ -lpthread)
  (install_c_headers binaryen-c))
 
+(install
+ (section lib)
+ (package libbinaryen)
+ (files
+  (wasm-delegations.def as c/wasm-delegations.def)))
+
 (rule
  (targets binaryen-c.h wasm-delegations.def)
  (deps


### PR DESCRIPTION
This ports our v102 fix to the main branch (which already tried to release a broken version of v103).

Closes #30 