### PR TITLE
fix: Ensure project can build with Opam on Windows

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ocaml-compiler: [4.12.0]
 
     steps:
@@ -25,6 +25,11 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+      - name: Inspect depexts
+        run: |
+          opam exec -- which python
+          opam exec -- which cmake
+
       - name: Install local dependencies
         run: opam install . --deps-only --with-test
 
@@ -32,5 +37,4 @@ jobs:
         run: opam exec -- dune build
 
       - name: Run tests
-        run: |
-          opam exec -- dune runtest
+        run: opam exec -- dune runtest

--- a/dune
+++ b/dune
@@ -113,6 +113,7 @@
      binaryen
      -G
      "Unix Makefiles"
+     -DCMAKE_SHARED_LIBRARY_PREFIX_CXX=lib
      -DBUILD_STATIC_LIB=OFF
      -DCMAKE_BUILD_TYPE=Release
      -DCMAKE_INSTALL_PREFIX=binaryen)

--- a/libbinaryen.opam
+++ b/libbinaryen.opam
@@ -18,3 +18,6 @@ depends: [
   "dune-configurator" {>= "2.9.1"}
   "ocaml" {>= "4.12"}
 ]
+depexts: [
+  ["gcc-g++"] { os-distribution = "cygwinports" }
+]


### PR DESCRIPTION
This actually relies on fixes in `conf-python-3` and `conf-cmake` to land in the mingw repository, so draft for now.

This is all the changes to get this project working from opam on windows.