### PR TITLE
chore: Ignore rebuilding binaryen.js on pushes to main

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,6 +1,8 @@
 name: Generate Binaryen.js
 on:
-  - push
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that squashing into `main` resulted in a new commit of the binaryen.js file. This will avoid any changes on main from regenerating the file.