### PR TITLE
fix: Disable the maybe-uninitialized error in newer gcc

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -13,16 +13,15 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '16'
+          node-version: "16"
           check-latest: true
 
       - name: "Set up emsdk"
         run: |
           mkdir $HOME/emsdk
           git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-          $HOME/emsdk/emsdk update-tags
-          $HOME/emsdk/emsdk install tot
-          $HOME/emsdk/emsdk activate tot
+          $HOME/emsdk/emsdk install 3.1.17
+          $HOME/emsdk/emsdk activate 3.1.17
           echo "$HOME/emsdk" >> $GITHUB_PATH
 
       - name: "Set up CMake"
@@ -34,7 +33,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: "Build binaryen.es5.js"
         run: |

--- a/dune
+++ b/dune
@@ -39,7 +39,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
+     "-DCMAKE_CXX_FLAGS=-Wno-unused-variable -Wno-maybe-uninitialized"
      -DBUILD_TESTS=OFF
      -DBUILD_TOOLS=OFF
      -DBUILD_STATIC_LIB=ON
@@ -66,7 +66,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
+     "-DCMAKE_CXX_FLAGS=-Wno-unused-variable -Wno-maybe-uninitialized"
      -DBUILD_TESTS=OFF
      -DBUILD_TOOLS=OFF
      -DBUILD_STATIC_LIB=OFF
@@ -95,7 +95,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
+     "-DCMAKE_CXX_FLAGS=-Wno-unused-variable -Wno-maybe-uninitialized"
      -DBUILD_TESTS=OFF
      -DBUILD_TOOLS=OFF
      -DBUILD_STATIC_LIB=OFF
@@ -122,7 +122,7 @@
      binaryen
      -G
      "Unix Makefiles"
-     -DCMAKE_CXX_FLAGS=-Wno-unused-variable
+     "-DCMAKE_CXX_FLAGS=-Wno-unused-variable -Wno-maybe-uninitialized"
      -DBUILD_TESTS=OFF
      -DBUILD_TOOLS=OFF
      -DCMAKE_SHARED_LIBRARY_PREFIX_CXX=lib


### PR DESCRIPTION
Binaryen seems to be failing to build in debian-11 CI runs on the opam repository. I'm trying to disable the `maybe-unitialized` error in GCC

Ref https://github.com/ocaml/opam-repository/pull/22337#issuecomment-1286556941
