### PR TITLE
chore: Update workflows to avoid deprecation warnings

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -15,25 +15,65 @@ jobs:
 
     steps:
       - name: Setup node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3.5.1
         with:
-          node-version: '14'
+          node-version: "16"
           check-latest: true
 
       # Install `esy` to build the project
+      # It also adds `shx` globally for cross-platform shell commands
       - name: Setup environment
         run: |
           npm i -g esy
+          npm i -g shx
 
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
-      - name: Esy build
-        uses: esy/github-action@d859489ca96411749931bceb4d733a2bdea922f9
+      - name: Install local dependencies
+        run: |
+          esy install
+
+      - name: Esy cache
+        id: esy-cache
+        uses: actions/cache@v3.0.11
         with:
-          cache-key: ${{ hashFiles('esy.lock/index.json') }}
+          path: _export
+          key: ${{ runner.os }}-esy-${{ hashFiles('esy.lock/index.json') }}
+
+      - name: Import esy cache
+        if: steps.esy-cache.outputs.cache-hit == 'true'
+        run: |
+          esy import-dependencies _export
+          shx rm -rf _export
+
+      # Build the project in release to make sure deps are specified correctly
+      - name: Build release dependencies
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        run: |
+          esy build-dependencies --release
+
+      - name: Build project in release
+        run: |
+          esy build --release
+
+      # Then build in non-release so we can test
+      - name: Build dependencies
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        run: |
+          esy build-dependencies
+
+      - name: Build project
+        run: |
+          esy build
+
+      # Re-export dependencies if anything has changed or if it is the first time
+      - name: Build esy cache
+        if: steps.esy-cache.outputs.cache-hit != 'true'
+        run: |
+          esy export-dependencies
 
       - name: Run tests
         run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Setup node.js
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: "16"
           check-latest: true
@@ -31,7 +31,7 @@ jobs:
           echo "$HOME/cmake/bin" >> $GITHUB_PATH
 
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3.1.0
+      - uses: GoogleCloudPlatform/release-please-action@v3.6.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
           brew install git-archive-all
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           submodules: "recursive"
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload Release Asset
         id: upload
-        uses: grain-lang/upload-release-action@v3.0.1
+        uses: grain-lang/upload-release-action@v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           file: ./libbinaryen.tar.gz
@@ -84,7 +84,7 @@ jobs:
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.12.0
+          ocaml-compiler: 4.14.0
 
       # Version 2.1.0 of opam-publish doesn't respect OPAMYES=1
       # Ref https://github.com/ocaml-opam/opam-publish/issues/132#issuecomment-963616802
@@ -102,9 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.5.1
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm


### PR DESCRIPTION
Had to drop the esy action because it doesn't seem to be maintained.

Closes #68 