### PR TITLE
feat!: Update binaryen to version_110

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -24,7 +24,7 @@ jobs:
       # It also adds `shx` globally for cross-platform shell commands
       - name: Setup environment
         run: |
-          npm i -g esy@next
+          npm i -g esy
           npm i -g shx
 
       - name: Checkout project

--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -24,7 +24,7 @@ jobs:
       # It also adds `shx` globally for cross-platform shell commands
       - name: Setup environment
         run: |
-          npm i -g esy
+          npm i -g esy@next
           npm i -g shx
 
       - name: Checkout project

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ocaml-compiler: [4.12.0, 4.13.1, 4.14.0]
+        ocaml-compiler: [4.12.1, 4.13.1, 4.14.0]
 
     steps:
       - name: Checkout project

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           submodules: "recursive"
 
+      # This is supposed to be solved by the time opam 2.2.0 is released
+      # Hack provided by https://github.com/ocaml/setup-ocaml/issues/529#issuecomment-1142547616
       - name: Hack Git CRLF for ocaml/setup-ocaml with MinGW and upstream repository
         if: ${{ startsWith(matrix.os, 'windows-') }}
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -20,10 +20,18 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Hack Git CRLF for ocaml/setup-ocaml with MinGW and upstream repository
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        run: |
+          git config --system core.autocrlf input
+
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            upstream: https://github.com/ocaml/opam-repository.git
+            default: https://github.com/fdopen/opam-repository-mingw.git#opam2
 
       - name: Inspect depexts
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -29,11 +29,18 @@ jobs:
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
+        if: ${{ startsWith(matrix.os, 'windows-') }}
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-repositories: |
             default: https://github.com/fdopen/opam-repository-mingw.git#opam2
             upstream: https://github.com/ocaml/opam-repository.git
+
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        if: ${{ !startsWith(matrix.os, 'windows-') }}
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Inspect depexts
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-repositories: |
-            upstream: https://github.com/ocaml/opam-repository.git
             default: https://github.com/fdopen/opam-repository-mingw.git#opam2
+            upstream: https://github.com/ocaml/opam-repository.git
 
       - name: Inspect depexts
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -36,4 +36,4 @@ jobs:
         run: opam exec -- dune build
 
       - name: Run tests
-        run: opam exec -- dune runtest
+        run: opam exec -- dune runtest --display=short

--- a/README.md
+++ b/README.md
@@ -53,22 +53,6 @@ If you are planning to create portable binaries for Windows, it will try to find
 
 These flags might not work on other operating systems (like MacOS), so you'll probably need to use `dune-configurator` to vary the flags per platform. You can see an example of this in our [tests/](./tests/dune).
 
-## JavaScript
-
-When compiling to JavaScript with `js_of_ocaml`, you'll need to add the `--disable share` flag. This is needed until we can depend on the bug fix from [ocsigen/js_of_ocaml#1249](https://github.com/ocsigen/js_of_ocaml/pull/1249). In the meantime, you can change your dune file:
-
-```diff
- (executable
-  (name example)
-  (public_name example)
-  (modes
-   (byte js))
-+ (js_of_ocaml
-+  (flags --disable share))
-  (modules example)
-  (libraries binaryen))
-```
-
 ## Contributing
 
 You'll need Node.js and [`esy`](https://esy.sh/docs/en/getting-started.html#install-esy) to build this project.

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.9)
+(lang dune 3.0)
 
 (name libbinaryen)

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,3 +1,3 @@
-(lang dune 2.9)
+(lang dune 3.0)
 
 (profile release)

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7c3ad1cbde6b9cafbc05bf8b74b7cbaf",
+  "checksum": "3f1f0fc65f620f74d6d5ca699f13b501",
   "root": "@grain/libbinaryen@link-dev:./package.json",
   "node": {
     "ocaml@4.14.0@d41d8cd9": {
@@ -35,37 +35,37 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@opam/cppo@opam:1.6.9@db929a12",
+        "@opam/dune@opam:3.6.0@79688ccb", "@opam/cppo@opam:1.6.9@db929a12",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/xdg@opam:3.5.0@e89f24d1": {
-      "id": "@opam/xdg@opam:3.5.0@e89f24d1",
+    "@opam/xdg@opam:3.6.0@a0d64bb5": {
+      "id": "@opam/xdg@opam:3.6.0@a0d64bb5",
       "name": "@opam/xdg",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "xdg",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/xdg.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/xdg.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/uutf@opam:1.0.3@47c95a18": {
@@ -86,7 +86,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.5@0aa59f51",
+        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.6@da3f4ab1",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
         "@opam/ocamlbuild@opam:0.14.2@c6163b28",
         "@opam/cmdliner@opam:1.1.1@03763729",
@@ -113,7 +113,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/uutf@opam:1.0.3@47c95a18",
-        "@opam/uucp@opam:15.0.0@55460339", "@opam/topkg@opam:1.0.5@0aa59f51",
+        "@opam/uucp@opam:15.0.0@55460339", "@opam/topkg@opam:1.0.6@da3f4ab1",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
         "@opam/ocamlbuild@opam:0.14.2@c6163b28",
         "@opam/cmdliner@opam:1.1.1@03763729",
@@ -142,7 +142,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/uutf@opam:1.0.3@47c95a18",
-        "@opam/topkg@opam:1.0.5@0aa59f51",
+        "@opam/topkg@opam:1.0.6@da3f4ab1",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
         "@opam/ocamlbuild@opam:0.14.2@c6163b28",
         "@opam/cmdliner@opam:1.1.1@03763729",
@@ -150,20 +150,20 @@
       ],
       "devDependencies": [ "ocaml@4.14.0@d41d8cd9" ]
     },
-    "@opam/topkg@opam:1.0.5@0aa59f51": {
-      "id": "@opam/topkg@opam:1.0.5@0aa59f51",
+    "@opam/topkg@opam:1.0.6@da3f4ab1": {
+      "id": "@opam/topkg@opam:1.0.6@da3f4ab1",
       "name": "@opam/topkg",
-      "version": "opam:1.0.5",
+      "version": "opam:1.0.6",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha512/94/9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab#sha512:9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab",
-          "archive:https://erratique.ch/software/topkg/releases/topkg-1.0.5.tbz#sha512:9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab"
+          "archive:https://opam.ocaml.org/cache/sha512/8e/8e34391e2f499cec332b79454a4edb36a35db6fe22437f017fd5c80ae065160dc967ac02d894a94d08d62dd476521e63733f4cadc3b9b6b314b6aa5b2b4ede78#sha512:8e34391e2f499cec332b79454a4edb36a35db6fe22437f017fd5c80ae065160dc967ac02d894a94d08d62dd476521e63733f4cadc3b9b6b314b6aa5b2b4ede78",
+          "archive:https://erratique.ch/software/topkg/releases/topkg-1.0.6.tbz#sha512:8e34391e2f499cec332b79454a4edb36a35db6fe22437f017fd5c80ae065160dc967ac02d894a94d08d62dd476521e63733f4cadc3b9b6b314b6aa5b2b4ede78"
         ],
         "opam": {
           "name": "topkg",
-          "version": "1.0.5",
-          "path": "esy.lock/opam/topkg.1.0.5"
+          "version": "1.0.6",
+          "path": "esy.lock/opam/topkg.1.0.6"
         }
       },
       "overrides": [],
@@ -176,35 +176,35 @@
         "ocaml@4.14.0@d41d8cd9", "@opam/ocamlbuild@opam:0.14.2@c6163b28"
       ]
     },
-    "@opam/stdune@opam:3.5.0@ea85fcde": {
-      "id": "@opam/stdune@opam:3.5.0@ea85fcde",
+    "@opam/stdune@opam:3.6.0@a5e22dd3": {
+      "id": "@opam/stdune@opam:3.6.0@a5e22dd3",
       "name": "@opam/stdune",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "stdune",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/stdune.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/stdune.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/pp@opam:1.1.2@89ad03b5",
-        "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/pp@opam:1.1.2@89ad03b5",
-        "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
@@ -227,11 +227,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/stdio@opam:v0.15.0@aeefdf96": {
@@ -252,12 +252,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base@opam:v0.15.1@e8a71f35",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base@opam:v0.15.1@e8a71f35"
       ]
     },
@@ -279,11 +279,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/sexplib0@opam:v0.15.1@51111c0c": {
@@ -304,11 +304,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -348,11 +348,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/re@opam:1.10.4@c4910ba6": {
@@ -374,11 +374,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/ppxlib@opam:0.28.0@8c51d241": {
@@ -403,14 +403,14 @@
         "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocaml-compiler-libs@opam:v0.12.4@41979882",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/stdlib-shims@opam:0.3.0@72c7bc98",
         "@opam/sexplib0@opam:v0.15.1@51111c0c",
         "@opam/ppx_derivers@opam:1.2.1@e2cbad12",
         "@opam/ocaml-compiler-libs@opam:v0.12.4@41979882",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7": {
@@ -432,11 +432,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/ppx_derivers@opam:1.2.1@e2cbad12": {
@@ -457,11 +457,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/pp@opam:1.1.2@89ad03b5": {
@@ -482,36 +482,36 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/ordering@opam:3.5.0@bc593f7a": {
-      "id": "@opam/ordering@opam:3.5.0@bc593f7a",
+    "@opam/ordering@opam:3.6.0@d25a6afc": {
+      "id": "@opam/ordering@opam:3.6.0@d25a6afc",
       "name": "@opam/ordering",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "ordering",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/ordering.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/ordering.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/omd@opam:1.3.2@511d53d2": {
@@ -532,13 +532,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@opam/base-bigarray@opam:base@b03491b0"
       ]
@@ -562,14 +562,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/camlp-streams@opam:5.0.1@daaa0f94",
         "@opam/astring@opam:0.8.5@1300cee8",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/result@opam:1.5@1c6a6533",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/camlp-streams@opam:5.0.1@daaa0f94",
         "@opam/astring@opam:0.8.5@1300cee8"
       ]
@@ -592,11 +592,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/ocp-indent@opam:1.7.0@2da3c6e5": {
@@ -618,14 +618,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/ocamlfind@opam:1.9.5@c23112ba",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/ocamlfind@opam:1.9.5@c23112ba",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -648,11 +648,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
@@ -680,14 +680,14 @@
         "@opam/odoc-parser@opam:2.0.0@a08011a0",
         "@opam/ocp-indent@opam:1.7.0@2da3c6e5",
         "@opam/ocaml-version@opam:3.5.0@6bef55f5",
-        "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/menhir@opam:20220210@ff87a93b",
+        "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/menhir@opam:20220210@ff5ea9a7",
         "@opam/fpath@opam:0.7.3@674d8125",
         "@opam/fix@opam:20220121@17b9a1a4",
         "@opam/either@opam:1.0.0@be5a1416",
-        "@opam/dune-build-info@opam:3.5.0@621e3e0f",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/dune-build-info@opam:3.6.0@889e8e4f",
+        "@opam/dune@opam:3.6.0@79688ccb", "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@opam/base@opam:v0.15.1@e8a71f35",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -699,14 +699,14 @@
         "@opam/odoc-parser@opam:2.0.0@a08011a0",
         "@opam/ocp-indent@opam:1.7.0@2da3c6e5",
         "@opam/ocaml-version@opam:3.5.0@6bef55f5",
-        "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/menhir@opam:20220210@ff87a93b",
+        "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/menhir@opam:20220210@ff5ea9a7",
         "@opam/fpath@opam:0.7.3@674d8125",
         "@opam/fix@opam:20220121@17b9a1a4",
         "@opam/either@opam:1.0.0@be5a1416",
-        "@opam/dune-build-info@opam:3.5.0@621e3e0f",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/dune-build-info@opam:3.6.0@889e8e4f",
+        "@opam/dune@opam:3.6.0@79688ccb", "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@opam/base@opam:v0.15.1@e8a71f35"
       ]
@@ -783,11 +783,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/ocaml-lsp-server@opam:1.12.4@c24ab770": {
@@ -809,36 +809,36 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
-        "@opam/xdg@opam:3.5.0@e89f24d1", "@opam/uutf@opam:1.0.3@47c95a18",
-        "@opam/stdune@opam:3.5.0@ea85fcde",
+        "@opam/xdg@opam:3.6.0@a0d64bb5", "@opam/uutf@opam:1.0.3@47c95a18",
+        "@opam/stdune@opam:3.6.0@a5e22dd3",
         "@opam/spawn@opam:v0.15.1@85e9d6f1", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7",
-        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.5.0@bc593f7a",
+        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.6.0@d25a6afc",
         "@opam/omd@opam:1.3.2@511d53d2",
         "@opam/octavius@opam:1.2.2@2205cc65",
         "@opam/ocamlformat-rpc-lib@opam:0.24.1@4b5db4b3",
-        "@opam/fiber@opam:3.5.0@56fce66b", "@opam/dyn@opam:3.5.0@5e82db53",
-        "@opam/dune-rpc@opam:3.5.0@80ba21cc",
-        "@opam/dune-build-info@opam:3.5.0@621e3e0f",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@opam/csexp@opam:1.5.1@8a8fb3a7",
-        "@opam/chrome-trace@opam:3.5.0@845aba37",
+        "@opam/fiber@opam:3.6.0@6dd9114e", "@opam/dyn@opam:3.6.0@cdd7d871",
+        "@opam/dune-rpc@opam:3.6.0@ff4fbfea",
+        "@opam/dune-build-info@opam:3.6.0@889e8e4f",
+        "@opam/dune@opam:3.6.0@79688ccb", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/chrome-trace@opam:3.6.0@e39574ee",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
-        "@opam/xdg@opam:3.5.0@e89f24d1", "@opam/uutf@opam:1.0.3@47c95a18",
-        "@opam/stdune@opam:3.5.0@ea85fcde",
+        "@opam/xdg@opam:3.6.0@a0d64bb5", "@opam/uutf@opam:1.0.3@47c95a18",
+        "@opam/stdune@opam:3.6.0@a5e22dd3",
         "@opam/spawn@opam:v0.15.1@85e9d6f1", "@opam/re@opam:1.10.4@c4910ba6",
         "@opam/ppx_yojson_conv_lib@opam:v0.15.0@773058a7",
-        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.5.0@bc593f7a",
+        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.6.0@d25a6afc",
         "@opam/omd@opam:1.3.2@511d53d2",
         "@opam/octavius@opam:1.2.2@2205cc65",
         "@opam/ocamlformat-rpc-lib@opam:0.24.1@4b5db4b3",
-        "@opam/fiber@opam:3.5.0@56fce66b", "@opam/dyn@opam:3.5.0@5e82db53",
-        "@opam/dune-rpc@opam:3.5.0@80ba21cc",
-        "@opam/dune-build-info@opam:3.5.0@621e3e0f",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@opam/csexp@opam:1.5.1@8a8fb3a7",
-        "@opam/chrome-trace@opam:3.5.0@845aba37"
+        "@opam/fiber@opam:3.6.0@6dd9114e", "@opam/dyn@opam:3.6.0@cdd7d871",
+        "@opam/dune-rpc@opam:3.6.0@ff4fbfea",
+        "@opam/dune-build-info@opam:3.6.0@889e8e4f",
+        "@opam/dune@opam:3.6.0@79688ccb", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@opam/chrome-trace@opam:3.6.0@e39574ee"
       ]
     },
     "@opam/ocaml-compiler-libs@opam:v0.12.4@41979882": {
@@ -859,15 +859,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/menhirSdk@opam:20220210@b8921e41": {
-      "id": "@opam/menhirSdk@opam:20220210@b8921e41",
+    "@opam/menhirSdk@opam:20220210@fe146ed3": {
+      "id": "@opam/menhirSdk@opam:20220210@fe146ed3",
       "name": "@opam/menhirSdk",
       "version": "opam:20220210",
       "source": {
@@ -884,15 +884,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/menhirLib@opam:20220210@e6562f4f": {
-      "id": "@opam/menhirLib@opam:20220210@e6562f4f",
+    "@opam/menhirLib@opam:20220210@9afeb270": {
+      "id": "@opam/menhirLib@opam:20220210@9afeb270",
       "name": "@opam/menhirLib",
       "version": "opam:20220210",
       "source": {
@@ -909,15 +909,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/menhir@opam:20220210@ff87a93b": {
-      "id": "@opam/menhir@opam:20220210@ff87a93b",
+    "@opam/menhir@opam:20220210@ff5ea9a7": {
+      "id": "@opam/menhir@opam:20220210@ff5ea9a7",
       "name": "@opam/menhir",
       "version": "opam:20220210",
       "source": {
@@ -934,56 +934,51 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "ocaml@4.14.0@d41d8cd9", "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/js_of_ocaml-compiler@opam:4.0.0@e10fcdb0": {
-      "id": "@opam/js_of_ocaml-compiler@opam:4.0.0@e10fcdb0",
+    "@opam/js_of_ocaml-compiler@opam:4.1.0@4d526669": {
+      "id": "@opam/js_of_ocaml-compiler@opam:4.1.0@4d526669",
       "name": "@opam/js_of_ocaml-compiler",
-      "version": "opam:4.0.0",
+      "version": "opam:4.1.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/df/df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e#sha256:df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e",
-          "archive:https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz#sha256:df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+          "archive:https://opam.ocaml.org/cache/sha256/91/91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef#sha256:91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef",
+          "archive:https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz#sha256:91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
         ],
         "opam": {
           "name": "js_of_ocaml-compiler",
-          "version": "4.0.0",
-          "path": "esy.lock/opam/js_of_ocaml-compiler.4.0.0"
+          "version": "4.1.0",
+          "path": "esy.lock/opam/js_of_ocaml-compiler.4.1.0"
         }
       },
-      "overrides": [
-        {
-          "opamoverride":
-            "esy.lock/overrides/opam__s__js__of__ocaml_compiler_opam__c__4.0.0_opam_override"
-        }
-      ],
+      "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
         "@opam/ppxlib@opam:0.28.0@8c51d241",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
-        "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/menhir@opam:20220210@ff87a93b",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/menhir@opam:20220210@ff5ea9a7",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/cmdliner@opam:1.1.1@03763729",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.2@eb65f292",
         "@opam/ppxlib@opam:0.28.0@8c51d241",
-        "@opam/menhirSdk@opam:20220210@b8921e41",
-        "@opam/menhirLib@opam:20220210@e6562f4f",
-        "@opam/menhir@opam:20220210@ff87a93b",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/menhirSdk@opam:20220210@fe146ed3",
+        "@opam/menhirLib@opam:20220210@9afeb270",
+        "@opam/menhir@opam:20220210@ff5ea9a7",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/cmdliner@opam:1.1.1@03763729"
       ]
     },
@@ -1005,7 +1000,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.5@0aa59f51",
+        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.6@da3f4ab1",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
         "@opam/ocamlbuild@opam:0.14.2@c6163b28",
         "@opam/astring@opam:0.8.5@1300cee8",
@@ -1033,38 +1028,38 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/fiber@opam:3.5.0@56fce66b": {
-      "id": "@opam/fiber@opam:3.5.0@56fce66b",
+    "@opam/fiber@opam:3.6.0@6dd9114e": {
+      "id": "@opam/fiber@opam:3.6.0@6dd9114e",
       "name": "@opam/fiber",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "fiber",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/fiber.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/fiber.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/stdune@opam:3.5.0@ea85fcde",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/stdune@opam:3.6.0@a5e22dd3",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/stdune@opam:3.5.0@ea85fcde",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/stdune@opam:3.6.0@a5e22dd3",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/either@opam:1.0.0@be5a1416": {
@@ -1085,136 +1080,136 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "@opam/dune@opam:3.5.0@fba55e5e" ]
+      "devDependencies": [ "@opam/dune@opam:3.6.0@79688ccb" ]
     },
-    "@opam/dyn@opam:3.5.0@5e82db53": {
-      "id": "@opam/dyn@opam:3.5.0@5e82db53",
+    "@opam/dyn@opam:3.6.0@cdd7d871": {
+      "id": "@opam/dyn@opam:3.6.0@cdd7d871",
       "name": "@opam/dyn",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "dyn",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/dyn.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/dyn.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/pp@opam:1.1.2@89ad03b5",
-        "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/pp@opam:1.1.2@89ad03b5",
-        "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/dune-rpc@opam:3.5.0@80ba21cc": {
-      "id": "@opam/dune-rpc@opam:3.5.0@80ba21cc",
+    "@opam/dune-rpc@opam:3.6.0@ff4fbfea": {
+      "id": "@opam/dune-rpc@opam:3.6.0@ff4fbfea",
       "name": "@opam/dune-rpc",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "dune-rpc",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/dune-rpc.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/dune-rpc.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "@opam/xdg@opam:3.5.0@e89f24d1", "@opam/stdune@opam:3.5.0@ea85fcde",
-        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/xdg@opam:3.6.0@a0d64bb5", "@opam/stdune@opam:3.6.0@a5e22dd3",
+        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/xdg@opam:3.5.0@e89f24d1", "@opam/stdune@opam:3.5.0@ea85fcde",
-        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.5.0@bc593f7a",
-        "@opam/dyn@opam:3.5.0@5e82db53", "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/xdg@opam:3.6.0@a0d64bb5", "@opam/stdune@opam:3.6.0@a5e22dd3",
+        "@opam/pp@opam:1.1.2@89ad03b5", "@opam/ordering@opam:3.6.0@d25a6afc",
+        "@opam/dyn@opam:3.6.0@cdd7d871", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
-    "@opam/dune-configurator@opam:3.5.0@5f776796": {
-      "id": "@opam/dune-configurator@opam:3.5.0@5f776796",
+    "@opam/dune-configurator@opam:3.6.0@3ecc1753": {
+      "id": "@opam/dune-configurator@opam:3.6.0@3ecc1753",
       "name": "@opam/dune-configurator",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "dune-configurator",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/dune-configurator.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/dune-configurator.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/csexp@opam:1.5.1@8a8fb3a7",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/dune-build-info@opam:3.5.0@621e3e0f": {
-      "id": "@opam/dune-build-info@opam:3.5.0@621e3e0f",
+    "@opam/dune-build-info@opam:3.6.0@889e8e4f": {
+      "id": "@opam/dune-build-info@opam:3.6.0@889e8e4f",
       "name": "@opam/dune-build-info",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "dune-build-info",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/dune-build-info.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/dune-build-info.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
-    "@opam/dune@opam:3.5.0@fba55e5e": {
-      "id": "@opam/dune@opam:3.5.0@fba55e5e",
+    "@opam/dune@opam:3.6.0@79688ccb": {
+      "id": "@opam/dune@opam:3.6.0@79688ccb",
       "name": "@opam/dune",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "dune",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/dune.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/dune.3.6.0"
         }
       },
       "overrides": [],
@@ -1246,11 +1241,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/cppo@opam:1.6.9@db929a12": {
@@ -1271,12 +1266,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -1318,29 +1313,29 @@
       ],
       "devDependencies": [ "ocaml@4.14.0@d41d8cd9" ]
     },
-    "@opam/chrome-trace@opam:3.5.0@845aba37": {
-      "id": "@opam/chrome-trace@opam:3.5.0@845aba37",
+    "@opam/chrome-trace@opam:3.6.0@e39574ee": {
+      "id": "@opam/chrome-trace@opam:3.6.0@e39574ee",
       "name": "@opam/chrome-trace",
-      "version": "opam:3.5.0",
+      "version": "opam:3.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/77/77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610",
-          "archive:https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz#sha256:77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
+          "archive:https://opam.ocaml.org/cache/sha256/08/08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278",
+          "archive:https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz#sha256:08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
         ],
         "opam": {
           "name": "chrome-trace",
-          "version": "3.5.0",
-          "path": "esy.lock/opam/chrome-trace.3.5.0"
+          "version": "3.6.0",
+          "path": "esy.lock/opam/chrome-trace.3.6.0"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/camlp-streams@opam:5.0.1@daaa0f94": {
@@ -1361,11 +1356,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e",
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.5.0@fba55e5e"
+        "ocaml@4.14.0@d41d8cd9", "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -1460,13 +1455,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune-configurator@opam:3.5.0@5f776796",
-        "@opam/dune@opam:3.5.0@fba55e5e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune-configurator@opam:3.6.0@3ecc1753",
+        "@opam/dune@opam:3.6.0@79688ccb", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/sexplib0@opam:v0.15.1@51111c0c",
-        "@opam/dune-configurator@opam:3.5.0@5f776796",
-        "@opam/dune@opam:3.5.0@fba55e5e"
+        "@opam/dune-configurator@opam:3.6.0@3ecc1753",
+        "@opam/dune@opam:3.6.0@79688ccb"
       ]
     },
     "@opam/astring@opam:0.8.5@1300cee8": {
@@ -1487,7 +1482,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.5@0aa59f51",
+        "ocaml@4.14.0@d41d8cd9", "@opam/topkg@opam:1.0.6@da3f4ab1",
         "@opam/ocamlfind@opam:1.9.5@c23112ba",
         "@opam/ocamlbuild@opam:0.14.2@c6163b28",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1506,14 +1501,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.14.0@d41d8cd9",
-        "@opam/dune-configurator@opam:3.5.0@5f776796",
-        "@opam/dune@opam:3.5.0@fba55e5e",
+        "@opam/dune-configurator@opam:3.6.0@3ecc1753",
+        "@opam/dune@opam:3.6.0@79688ccb",
         "@opam/conf-cmake@github:grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/ocamlformat@opam:0.24.1@80ba1b34",
         "@opam/ocaml-lsp-server@opam:1.12.4@c24ab770",
-        "@opam/js_of_ocaml-compiler@opam:4.0.0@e10fcdb0"
+        "@opam/js_of_ocaml-compiler@opam:4.1.0@4d526669"
       ],
       "installConfig": { "pnp": false }
     },

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3f1f0fc65f620f74d6d5ca699f13b501",
+  "checksum": "c6e43906dd79291af8c22ce49e471ae7",
   "root": "@grain/libbinaryen@link-dev:./package.json",
   "node": {
     "ocaml@4.14.0@d41d8cd9": {

--- a/esy.lock/opam/chrome-trace.3.6.0/opam
+++ b/esy.lock/opam/chrome-trace.3.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Structured concurrency library"
+synopsis: "Chrome trace event generation library"
 description:
   "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
@@ -9,10 +9,8 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08.0"}
-  "stdune" {= version}
-  "dyn" {= version}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
@@ -32,10 +30,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/dune-build-info.3.6.0/opam
+++ b/esy.lock/opam/dune-build-info.3.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Embed build informations inside executable"
+synopsis: "Embed build information inside executable"
 description: """
 The build-info library allows to access information about how the
 executable was built, such as the version of the project at which it
@@ -15,7 +15,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
@@ -36,10 +36,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/dune-configurator.3.6.0/opam
+++ b/esy.lock/opam/dune-configurator.3.6.0/opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.04.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}
@@ -40,10 +40,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/dune-rpc.3.6.0/opam
+++ b/esy.lock/opam/dune-rpc.3.6.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Element ordering"
-description: "Element ordering"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
 maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 license: "MIT"
@@ -8,8 +8,13 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
-  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.5"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
@@ -29,10 +34,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/dune.3.6.0/opam
+++ b/esy.lock/opam/dune.3.6.0/opam
@@ -36,8 +36,8 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  ["ocaml" "bootstrap.ml" "-j" jobs]
-  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
@@ -47,10 +47,10 @@ depends: [
   "base-threads"
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/dyn.3.6.0/opam
+++ b/esy.lock/opam/dyn.3.6.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08.0"}
   "ordering" {= version}
   "pp" {>= "1.1.0"}
@@ -31,10 +31,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/fiber.3.6.0/opam
+++ b/esy.lock/opam/fiber.3.6.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
-synopsis: "Communicate with dune using rpc"
-description: "Library to connect and control a running dune instance"
+synopsis: "Structured concurrency library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 license: "MIT"
@@ -8,13 +9,10 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
-  "csexp"
-  "ordering"
-  "dyn"
-  "xdg"
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
   "stdune" {= version}
-  "pp" {>= "1.1.0"}
+  "dyn" {= version}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
@@ -34,10 +32,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/js_of_ocaml-compiler.4.1.0/opam
+++ b/esy.lock/opam/js_of_ocaml-compiler.4.1.0/opam
@@ -10,13 +10,13 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "2.9"}
-  "ocaml" {>= "4.04" & < "4.15"}
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04" & < "5.1"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.1.0"}
   "menhir"
   "menhirLib"
   "menhirSdk"
@@ -27,7 +27,6 @@ depopts: ["ocamlfind"]
 conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
-  "base-domains"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [
@@ -39,18 +38,16 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 url {
   src:
-    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
   checksum: [
-    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
-    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
   ]
 }
-x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/esy.lock/opam/menhir.20220210/opam
+++ b/esy.lock/opam/menhir.20220210/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://gitlab.inria.fr/fpottier/menhir"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/esy.lock/opam/menhirLib.20220210/opam
+++ b/esy.lock/opam/menhirLib.20220210/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://gitlab.inria.fr/fpottier/menhir"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/esy.lock/opam/menhirSdk.20220210/opam
+++ b/esy.lock/opam/menhirSdk.20220210/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://gitlab.inria.fr/fpottier/menhir"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/esy.lock/opam/ordering.3.6.0/opam
+++ b/esy.lock/opam/ordering.3.6.0/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
-synopsis: "Dune's unstable standard library"
-description:
-  "This library offers no backwards compatibility guarantees. Use at your own risk."
+synopsis: "Element ordering"
+description: "Element ordering"
 maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 license: "MIT"
@@ -9,13 +8,8 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08.0"}
-  "base-unix"
-  "dyn" {= version}
-  "ordering" {= version}
-  "pp" {>= "1.1.0"}
-  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
@@ -35,10 +29,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/stdune.3.6.0/opam
+++ b/esy.lock/opam/stdune.3.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Chrome trace event generation library"
+synopsis: "Dune's unstable standard library"
 description:
   "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
@@ -9,8 +9,13 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
@@ -30,10 +35,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/opam/topkg.1.0.6/opam
+++ b/esy.lock/opam/topkg.1.0.6/opam
@@ -1,22 +1,6 @@
 opam-version: "2.0"
-synopsis: """The transitory OCaml software packager"""
-maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
-authors: ["The topkg programmers"]
-homepage: "https://erratique.ch/software/topkg"
-doc: "https://erratique.ch/software/topkg/doc"
-dev-repo: "git+https://erratique.ch/repos/topkg.git"
-bug-reports: "https://github.com/dbuenzli/topkg/issues"
-license: ["ISC"]
-tags: ["packaging" "ocamlbuild" "org:erratique"]
-depends: ["ocaml" {>= "4.05.0"}
-          "ocamlfind" {build & >= "1.6.1"}
-          "ocamlbuild"]
-build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
-                                      "--dev-pkg" "%{dev}%"]]
-url {
-  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.5.tbz"
-  checksum: "sha512=9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab"}
-description: """
+synopsis: "The transitory OCaml software packager"
+description: """\
 Topkg is a packager for distributing OCaml software. It provides an
 API to describe the files a package installs in a given build
 configuration and to specify information about the package's
@@ -42,3 +26,22 @@ Topkg-care is distributed under the ISC license it depends on
 [webbrowser]: http://erratique.ch/software/webbrowser
 
 Home page: http://erratique.ch/software/topkg"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The topkg programmers"
+license: "ISC"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.6.tbz"
+  checksum:
+    "sha512=8e34391e2f499cec332b79454a4edb36a35db6fe22437f017fd5c80ae065160dc967ac02d894a94d08d62dd476521e63733f4cadc3b9b6b314b6aa5b2b4ede78"
+}

--- a/esy.lock/opam/xdg.3.6.0/opam
+++ b/esy.lock/opam/xdg.3.6.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
@@ -30,10 +30,10 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/3.5.0/dune-3.5.0.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz"
   checksum: [
-    "sha256=77bd4c6704359fae1969636cfc3cd7a517ba3604819ef89c919c0762b5093610"
-    "sha512=acaed76ab8618977118579641a1f6734ed4a225ab46494c6c5fd8e1bf9a0889e62db9adc7bd11770da602f4dd4785cef5ece4ad26512d08b64b8f3bd8954c80d"
+    "sha256=08a0c6c9521604e60cf36afba036ecf1b107df51eed14a2fb7eef6cfdd2bf278"
+    "sha512=71b94cb7cad4c6f998da5bd59fe3c6d0b4a4188896ae04aa0ffff7142ced0b93bce3a88c3b5b7b7c8c948d10ccfb2fb81fcf764aa421b595e061ac3049fa8870"
   ]
 }
-x-commit-hash: "77c1e6f8f27f57fe0c04ec1624a85069b02437cf"
+x-commit-hash: "c3b75bdfd3763b39aaac8baa5104312ac701d501"

--- a/esy.lock/overrides/opam__s__js__of__ocaml_compiler_opam__c__4.0.0_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__js__of__ocaml_compiler_opam__c__4.0.0_opam_override/package.json
@@ -1,3 +1,0 @@
-{
-  "build": "dune build -p js_of_ocaml-compiler"
-}

--- a/libbinaryen.opam
+++ b/libbinaryen.opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-cmake" {build}
-  "dune" {>= "2.9.1"}
-  "dune-configurator" {>= "2.9.1"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
   "js_of_ocaml-compiler" {with-test & >= "3.10.0" < "5.0.0"}
   "ocaml" {>= "4.12"}
 ]

--- a/libbinaryen.opam
+++ b/libbinaryen.opam
@@ -15,7 +15,7 @@ depends: [
   "conf-cmake" {build}
   "dune" {>= "3.0.0"}
   "dune-configurator" {>= "3.0.0"}
-  "js_of_ocaml-compiler" {with-test & >= "3.10.0" < "5.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" < "5.0.0"}
   "ocaml" {>= "4.12"}
 ]
 depexts: [

--- a/libbinaryen.opam
+++ b/libbinaryen.opam
@@ -21,6 +21,3 @@ depends: [
 depexts: [
   ["gcc-g++"] { os-distribution = "cygwinports" }
 ]
-pin-depends: [
-  ["js_of_ocaml-compiler.4.1.0" "git+https://github.com/ocsigen/js_of_ocaml#4.1.0"]
-]

--- a/libbinaryen.opam
+++ b/libbinaryen.opam
@@ -21,3 +21,6 @@ depends: [
 depexts: [
   ["gcc-g++"] { os-distribution = "cygwinports" }
 ]
+pin-depends: [
+  ["js_of_ocaml-compiler.4.1.0" "git+https://github.com/ocsigen/js_of_ocaml#4.1.0"]
+]

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "ocaml": ">= 4.12.0",
     "@opam/conf-cmake": "grain-lang/cmake:esy.json#1cead3871bbb27a45adab2263ef2dff4a38a8869",
-    "@opam/dune": ">= 2.9.1",
-    "@opam/dune-configurator": ">= 2.9.1"
+    "@opam/dune": ">= 3.0.0",
+    "@opam/dune-configurator": ">= 3.0.0"
   },
   "devDependencies": {
     "@opam/js_of_ocaml-compiler": ">= 3.10.0 < 5.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "scripts": {
-    "test": "esy b dune runtest",
+    "test": "dune runtest --display=short",
     "format": "dune build @fmt --auto-promote"
   },
   "installConfig": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@opam/dune-configurator": ">= 3.0.0"
   },
   "devDependencies": {
-    "@opam/js_of_ocaml-compiler": ">= 3.10.0 < 5.0.0",
+    "@opam/js_of_ocaml-compiler": ">= 4.1.0 < 5.0.0",
     "@opam/ocamlformat": "0.24.1",
     "@opam/ocaml-lsp-server": "> 1.9.1 < 1.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "scripts": {
-    "test": "dune runtest --display=short",
+    "test": "esy b dune runtest --display=short",
     "format": "dune build @fmt --auto-promote"
   },
   "installConfig": {

--- a/test/dune
+++ b/test/dune
@@ -9,10 +9,8 @@
  (js_of_ocaml
   (javascript_files types.js)))
 
-(tests
- (names test)
- (enabled_if
-  (= {bin-available:node} true))
+(test
+ (name test)
  (modules test)
  (libraries binaryen)
  (modes exe js)
@@ -21,14 +19,3 @@
   (:include ./config/flags.sexp))
  (js_of_ocaml
   (flags --no-sourcemap)))
-
-(tests
- (names test)
- (enabled_if
-  (= {bin-available:node} false))
- (modules test)
- (libraries binaryen)
- (modes exe)
- (flags
-  :standard
-  (:include ./config/flags.sexp)))

--- a/test/dune
+++ b/test/dune
@@ -11,6 +11,8 @@
 
 (tests
  (names test)
+ (enabled_if
+  (= {bin-available:node} true))
  (modules test)
  (libraries binaryen)
  (modes exe js)
@@ -19,3 +21,14 @@
   (:include ./config/flags.sexp))
  (js_of_ocaml
   (flags --no-sourcemap)))
+
+(tests
+ (names test)
+ (enabled_if
+  (= {bin-available:node} false))
+ (modules test)
+ (libraries binaryen)
+ (modes exe)
+ (flags
+  :standard
+  (:include ./config/flags.sexp)))

--- a/test/dune
+++ b/test/dune
@@ -9,31 +9,13 @@
  (js_of_ocaml
   (javascript_files types.js)))
 
-(test
- (name test)
+(tests
+ (names test)
  (modules test)
  (libraries binaryen)
+ (modes exe js)
  (flags
   :standard
   (:include ./config/flags.sexp))
- (action
-  (run %{test})))
-
-(rule
- (target test_js.ml)
- (action
-  (copy %{dep:test.ml} %{target})))
-
-(test
- (name test_js)
- (enabled_if
-  ; TODO: Switch to `bin-available:node` after dune 3
-  (<> %{system} mingw64))
- (modules test_js)
- (modes
-  (byte js))
- (libraries binaryen)
- (action
-  (run node %{dep:test_js.bc.js}))
  (js_of_ocaml
-  (flags --no-sourcemap --disable share)))
+  (flags --no-sourcemap)))

--- a/test/dune
+++ b/test/dune
@@ -11,6 +11,8 @@
 
 (test
  (name test)
+ (enabled_if
+  (= %{bin-available:node} true))
  (modules test)
  (libraries binaryen)
  (modes exe js)
@@ -19,3 +21,19 @@
   (:include ./config/flags.sexp))
  (js_of_ocaml
   (flags --no-sourcemap)))
+
+(rule
+ (target test_no_js.ml)
+ (action
+  (copy %{dep:test.ml} %{target})))
+
+(test
+ (name test_no_js)
+ (enabled_if
+  (= %{bin-available:node} false))
+ (modules test_no_js)
+ (libraries binaryen)
+ (modes exe)
+ (flags
+  :standard
+  (:include ./config/flags.sexp)))


### PR DESCRIPTION
This upgrades binaryen to `version_110`

I also decided to drop support for dune 2 because dune 3 has a lot of QoL stuff for js_of_ocaml (like running tests in node by default)

Then, I realized that jsoo v4.1 was finally released, which has a optimizer fix that we need. So I set that as our minimum version... but then found that it isn't published in the mingw repository yet (so this is a draft currently).

Closes #50