### PR TITLE
feat!: Update to libbinaryen v115

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -20,8 +20,8 @@ jobs:
         run: |
           mkdir $HOME/emsdk
           git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
-          $HOME/emsdk/emsdk install 3.1.17
-          $HOME/emsdk/emsdk activate 3.1.17
+          $HOME/emsdk/emsdk install 3.1.47
+          $HOME/emsdk/emsdk activate 3.1.47
           echo "$HOME/emsdk" >> $GITHUB_PATH
 
       - name: "Set up CMake"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "binaryen"]
 	path = binaryen
-	url = https://github.com/peblair/binaryen
+	url = https://github.com/WebAssembly/binaryen

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "binaryen"]
 	path = binaryen
-	url = https://github.com/WebAssembly/binaryen
+	url = https://github.com/peblair/binaryen


### PR DESCRIPTION
`binaryen-c.h` diff:
```diff
diff --git a/src/binaryen-c.h b/src/binaryen-c.h
index 07c116aec..f4f4f2d74 100644
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -230,7 +230,7 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureMemory64(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureRelaxedSIMD(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureExtendedConst(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureStrings(void);
-BINARYEN_API BinaryenFeatures BinaryenFeatureMultiMemories(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureMultiMemory(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 
 // Modules
@@ -2723,6 +2723,15 @@ BinaryenAddFunction(BinaryenModuleRef module,
                     BinaryenType* varTypes,
                     BinaryenIndex numVarTypes,
                     BinaryenExpressionRef body);
+// As BinaryenAddFunction, but takes a HeapType rather than params and results.
+// This lets you set the specific type of the function.
+BINARYEN_API BinaryenFunctionRef
+BinaryenAddFunctionWithHeapType(BinaryenModuleRef module,
+                                const char* name,
+                                BinaryenHeapType type,
+                                BinaryenType* varTypes,
+                                BinaryenIndex numVarTypes,
+                                BinaryenExpressionRef body);
 // Gets a function reference by name. Returns NULL if the function does not
 // exist.
 BINARYEN_API BinaryenFunctionRef BinaryenGetFunction(BinaryenModuleRef module,
@@ -3563,6 +3572,9 @@ BINARYEN_API BinaryenType TypeBuilderGetTempRefType(TypeBuilderRef builder,
 BINARYEN_API void TypeBuilderSetSubType(TypeBuilderRef builder,
                                         BinaryenIndex index,
                                         BinaryenHeapType superType);
+// Sets the type at `index` to be open (i.e. non-final).
+BINARYEN_API void TypeBuilderSetOpen(TypeBuilderRef builder,
+                                     BinaryenIndex index);
 // Creates a new recursion group in the range `index` inclusive to `index +
 // length` exclusive. Recursion groups must not overlap.
 BINARYEN_API void TypeBuilderCreateRecGroup(TypeBuilderRef builder,
```
`passes/pass.cpp` diff:
```diff
diff --git a/src/passes/pass.cpp b/src/passes/pass.cpp
index adaa42e04..0d47cd78e 100644
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -187,6 +187,9 @@ void PassRegistry::registerPasses() {
                "information about what content can actually appear in each "
                "location",
                createGUFAPass);
+  registerPass("gufa-cast-all",
+               "GUFA plus add casts for all inferences",
+               createGUFACastAllPass);
   registerPass("gufa-optimizing",
                "GUFA plus local optimizations in functions we modified",
                createGUFAOptimizingPass);
@@ -375,6 +378,9 @@ void PassRegistry::registerPasses() {
   registerPass("remove-unused-types",
                "remove unused private GC types",
                createRemoveUnusedTypesPass);
+  registerPass("reorder-functions-by-name",
+               "sorts functions by name (useful for debugging)",
+               createReorderFunctionsByNamePass);
   registerPass("reorder-functions",
                "sorts functions by access frequency",
                createReorderFunctionsPass);
```
`CMakeLists.txt` diff:
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 8a008b514..df1719a75 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 # to reduce this for compatability with emsdk.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
 
-project(binaryen LANGUAGES C CXX VERSION 114)
+project(binaryen LANGUAGES C CXX VERSION 115)
 include(GNUInstallDirs)
 
 # The C++ standard whose features are required to build Binaryen.
```