### PR TITLE
fix: Don't include binaryen submodules so Windows builds with opam

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Install local dependencies
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@c2e6bb92370612b89f302c3aaefa1da45ee2d702 # v3.2.15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Build archive
         run: |
-          git-archive-all --force-submodules libbinaryen.tar.gz
+          git-archive-all libbinaryen.tar.gz
 
       - name: Upload Release Asset
         id: upload


### PR DESCRIPTION
Windows builds of binaryen.ml are failing because paths included in binaryen submodules used for testing end up being too long because of the way opam sets up its directory structure. This PR makes no code changes; it only changes how releases are prepared by not including the submodules. This build with no submodules is tested in CI in both the esy and opam workflows.

An example of the failure can be found in this run: https://github.com/grain-lang/binaryen.ml/actions/runs/19006995118/job/54401493486

I published a version of libbinaryen to my opam fork which does not include the submodules, and you can see it passing in binaryen.ml here: https://github.com/grain-lang/binaryen.ml/actions/runs/19123129929/job/54647560908?pr=208