### PR TITLE
fix: Don't include binaryen submodules so Windows builds with opam

### DIFF
--- a/.github/workflows/esy.yml
+++ b/.github/workflows/esy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Install local dependencies
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@c2e6bb92370612b89f302c3aaefa1da45ee2d702 # v3.2.15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: "recursive"
+          submodules: true
 
       - name: Build archive
         run: |
-          git-archive-all --force-submodules libbinaryen.tar.gz
+          git-archive-all libbinaryen.tar.gz
 
       - name: Upload Release Asset
         id: upload


### PR DESCRIPTION
This patches v122 to fix builds on Windows.